### PR TITLE
Fix broken internal links

### DIFF
--- a/src/_posts/2015-05-09-close-look-at-dirty-boards.md
+++ b/src/_posts/2015-05-09-close-look-at-dirty-boards.md
@@ -12,9 +12,10 @@ toc: true
 
 [As I mentioned earlier]({% post_url
 2015-01-13-my-dirty-isousbrs422-boards-arrived %}) for my first open source
-project called [isoUSBRS422](index.md), I ordered PCBs from
-[dirtypcbs.com](https://dirtypcbs.com). They arrived in January. I took some
-photos using USB microscope.
+project called [isoUSBRS422]({% link
+_projects/isousbrs422.md %}), I ordered
+PCBs from [dirtypcbs.com](https://dirtypcbs.com). They arrived in January. I
+took some photos using USB microscope.
 
 Boards are dirty. Especially, soldermask layers aren't perfect. My first
 prototype is work as I expected. So they should be fine in terms of electrical

--- a/src/_projects/accloud.md
+++ b/src/_projects/accloud.md
@@ -4,8 +4,6 @@ excerpt: ACCLOUD (ACcelerated CLOUD), A Novel, FPGA Accelerated Cloud Architectu
 date: 2018-04-15
 tags:
     - en
-    - cloud
-    - accloud
 header:
     overlay_image: /assets/images/project/accloud-header.png
     overlay_filter: 0.5

--- a/src/_publications/ekici2019accloud.md
+++ b/src/_publications/ekici2019accloud.md
@@ -4,9 +4,6 @@ excerpt: 2019 27th Signal Processing and Communications Applications Conference 
 date: 2019-04-24
 tags:
     - tr
-    - resource-allocation
-    - cloud
-    - accloud
 header:
     overlay_image: /assets/images/publication/ekici2019accloud-promo.png
     overlay_filter: 0.5

--- a/src/_publications/ekici2019resource.md
+++ b/src/_publications/ekici2019resource.md
@@ -4,9 +4,6 @@ excerpt: 2019 28th International Conference on Computer Communication and Networ
 date: 2019-07-29
 tags:
     - en
-    - resource-allocation
-    - cloud
-    - accloud
 header:
     overlay_image: /assets/images/publication/ekici2019resource-promo.png
     overlay_filter: 0.5

--- a/src/_publications/erol2019generalization.md
+++ b/src/_publications/erol2019generalization.md
@@ -4,9 +4,6 @@ excerpt: 2019 27th Signal Processing and Communications Applications Conference 
 date: 2019-04-24
 tags:
     - tr
-    - openstack
-    - cloud
-    - accloud
 header:
     overlay_image: /assets/images/publication/erol2019generalization-promo.png
     overlay_filter: 0.5

--- a/src/_publications/erol2019openstack.md
+++ b/src/_publications/erol2019openstack.md
@@ -4,9 +4,6 @@ excerpt: 2019 28th International Conference on Computer Communication and Networ
 date: 2019-07-29
 tags:
     - en
-    - openstack
-    - cloud
-    - accloud
 header:
     overlay_image: /assets/images/publication/erol2019openstack-promo.png
     overlay_filter: 0.5

--- a/src/_publications/koltuk2019cloudgen.md
+++ b/src/_publications/koltuk2019cloudgen.md
@@ -4,9 +4,6 @@ excerpt: 2019 27th Signal Processing and Communications Applications Conference 
 date: 2019-04-24
 tags:
     - tr
-    - workload
-    - cloud
-    - accloud
 header:
     overlay_image: /assets/images/publication/koltuk2019cloudgen-promo.png
     overlay_filter: 0.5

--- a/src/_publications/yazar2014ee604.md
+++ b/src/_publications/yazar2014ee604.md
@@ -4,7 +4,6 @@ excerpt: 2014 compiled lecture notes of EE604 Sensor Array Signal Processing cou
 date: 2014-08-11
 tags:
     - en
-    - lecture-note
 header:
     overlay_image: /assets/images/publication/yazar2014ee604-promo.png
     overlay_filter: 0.5

--- a/src/_publications/yazar2015analysis.md
+++ b/src/_publications/yazar2015analysis.md
@@ -4,7 +4,6 @@ excerpt: 2015 23nd Signal Processing and Communications Applications Conference 
 date: 2015-05-16
 tags:
     - tr
-    - f-test
 header:
     overlay_image: /assets/images/publication/yazar2015analysis-promo.png
     overlay_filter: 0.5

--- a/src/_publications/yazar2015application.md
+++ b/src/_publications/yazar2015application.md
@@ -4,8 +4,6 @@ excerpt: 2015 Master's thesis.
 date: 2015-08-26
 tags:
     - en
-    - f-test
-    - thesis
 header:
     overlay_image: /assets/images/publication/yazar2015application-promo.png
     overlay_filter: 0.5

--- a/src/_publications/yazar2015metugrw.md
+++ b/src/_publications/yazar2015metugrw.md
@@ -4,7 +4,6 @@ excerpt: 2015 METU EEE Graduate Research Workshop (GRW). METU.
 date: 2015-03-05
 tags:
     - en
-    - f-test
 header:
     overlay_image: /assets/images/publication/yazar2015metugrw-promo.png
     overlay_filter: 0.5

--- a/src/_publications/yazar2017ee533.md
+++ b/src/_publications/yazar2017ee533.md
@@ -4,7 +4,6 @@ excerpt: 2017 compiled lecture notes of EE533 Information Theory course
 date: 2017-02-25
 tags:
     - en
-    - lecture-note
 header:
     overlay_image: /assets/images/publication/yazar2017ee533-promo.jpg
     overlay_filter: 0.5

--- a/src/_publications/yazar2018accloud.md
+++ b/src/_publications/yazar2018accloud.md
@@ -4,9 +4,6 @@ excerpt: 2018 26th Signal Processing and Communications Applications Conference 
 date: 2018-05-02
 tags:
     - tr
-    - fpga
-    - cloud
-    - accloud
 header:
     overlay_image: /assets/images/publication/yazar2018accloud-promo.png
     overlay_filter: 0.5

--- a/src/_publications/yazar2018freertos.md
+++ b/src/_publications/yazar2018freertos.md
@@ -4,7 +4,6 @@ excerpt: 2018 9. Savunma Teknolojileri Kongresi (SAVTEK). SAVTEK.
 date: 2018-06-27
 tags:
     - tr
-    - freertos
 header:
     overlay_image: /assets/images/publication/yazar2018freertos-promo.png
     overlay_filter: 0.5

--- a/src/_publications/yazici2020novel.md
+++ b/src/_publications/yazici2020novel.md
@@ -4,9 +4,6 @@ excerpt: 2020 IEEE 9th International Conference on Cloud Networking (CloudNet). 
 date: 2020-11-09
 tags:
     - en
-    - noc
-    - cloud
-    - accloud
 header:
     overlay_image: /assets/images/publication/yazici2020novel-promo.png
     overlay_filter: 0.5

--- a/src/_publications/yazici2020onchip.md
+++ b/src/_publications/yazici2020onchip.md
@@ -4,9 +4,6 @@ excerpt: 2020 28th Signal Processing and Communications Applications Conference 
 date: 2020-10-05
 tags:
     - tr
-    - noc
-    - cloud
-    - accloud
 header:
     overlay_image: /assets/images/publication/yazici2020onchip-promo.png
     overlay_filter: 0.5


### PR DESCRIPTION
* Fix broken link from dirtypcbs.com review post to isoUSBRS422 project
* Remove tags from collections: publications, patents, projects since native Jekyll or jekyll-archive plugin don't support tags anywhere except on posts. I kept only language tags, en/tr, on collections since they are already exist for posts. Non-exisist tags generates broken links. See: https://github.com/jekyll/jekyll/pull/5857 https://github.com/jekyll/jekyll-archives/pull/88
